### PR TITLE
patch 20200119 修正url 白名单 为 强匹配防止利用绕过

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -54,7 +54,7 @@ function white_url_check()
                     local rule_str = string.sub(rule,1,2)
                     local from, to, err = rulematch(REQ_URI,string.lower(rule),"jo")
                     if rule_str == "\\." then
-                        local wfrom, wto, werr = rulematch(REQ_URI,"%?","jo")
+                        local wfrom, wto, werr = rulematch(unescape(REQ_URI),"%?","jo")
                         if from and REQ_URI_LEN == to and wfrom == nil then
                             return true
                         end

--- a/init.lua
+++ b/init.lua
@@ -49,8 +49,20 @@ function white_url_check()
         local REQ_URI = string.lower(ngx.var.request_uri)
         if URL_WHITE_RULES ~= nil then
             for _,rule in pairs(URL_WHITE_RULES) do
-                if rule ~= "" and rulematch(REQ_URI,string.lower(rule),"jo") then
-                    return true
+                if rule ~= "" then
+                    local REQ_URI_LEN = string.len(REQ_URI)
+                    local rule_str = string.sub(rule,1,2)
+                    local from, to, err = rulematch(REQ_URI,string.lower(rule),"jo")
+                    if rule_str == "\\." then
+                        local wfrom, wto, werr = rulematch(REQ_URI,"%?","jo")
+                        if from and REQ_URI_LEN == to and wfrom == nil then
+                            return true
+                        end
+                    elseif from and rule_str == "\\/" and from == 1 then
+                        return true
+                    elseif from and from == 2 then
+                        return true
+                    end
                 end
             end
         end


### PR DESCRIPTION
说明:
1.whiteurl 规则 从\. 开始匹配的静态文件名相当于排除此扩展名的静态文件，如果是URL动态路径带?的路径里包含静态文件名不生效
2.例如原captcha-waf\.html规则，修改后表示从网站根目录下captcha-waf.html文件符合规则，如果文件在/xxx/captcha-waf.html下则不符合规则，也就是修改后从根目录下从头开始匹配，防止利用绕过。
3.可能带来的其他问题目前测试还未知