### PR TITLE
fix ngx_lua_version bug

### DIFF
--- a/resty/core/base.lua
+++ b/resty/core/base.lua
@@ -19,9 +19,9 @@ if subsystem == 'http' then
     local ngx_lua_v = ngx.config.ngx_lua_version
     if not ngx.config
        or not ngx.config.ngx_lua_version
-       or (ngx_lua_v ~= 10016 and ngx_lua_v ~= 10017)
+       or (ngx_lua_v ~= 10019 and ngx_lua_v ~= 10020)
     then
-        error("ngx_http_lua_module 0.10.16 or 0.10.17 required")
+        error("ngx_http_lua_module 0.10.19 or 0.10.20 required")
     end
 
 elseif subsystem == 'stream' then


### PR DESCRIPTION
修复更换lua-nginx-module版本之后，base.lua中版本不匹配导致启动nginx失败。
我对比了下，官方版本也是逐代版本修改，见[issue](https://github.com/openresty/lua-resty-core/commits/master/lib/resty/core/base.lua)。